### PR TITLE
Fix authorization

### DIFF
--- a/src/main/java/com/gibgab/service/beans/SecurityConfiguration.java
+++ b/src/main/java/com/gibgab/service/beans/SecurityConfiguration.java
@@ -9,56 +9,26 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 public class SecurityConfiguration {
 
     @Value("#{'${pages.public.get}'.split(',')}")
-    private String[] publicAccessGetPages;
+    public String[] publicAccessGetPages;
 
     @Value("#{'${pages.public.post}'.split(',')}")
-    private String[] publicAccessPostPages;
+    public String[] publicAccessPostPages;
 
     @Value("#{'${pages.secure.moderator}'.split(',')}")
-    private String[] moderatorPages;
+    public String[] moderatorPages;
 
     @Value("#{'${pages.secure.user}'.split(',')}")
-    private String[] userPages;
+    public String[] userPages;
 
 
     @Value("#{'${security.role.moderator}'}")
-    private String moderatorRole;
+    public String moderatorRole;
 
     @Value("#{'${security.role.user}'}")
-    private String userRole;
+    public String userRole;
 
     @Bean
     public BCryptPasswordEncoder bCryptPasswordEncoder(){
         return new BCryptPasswordEncoder();
-    }
-
-    @Bean
-    public String[] publicAccessGetPages(){
-        return publicAccessGetPages;
-    }
-
-    @Bean
-    public String[] publicAccessPostPages(){
-        return publicAccessPostPages;
-    }
-
-    @Bean
-    public String[] moderatorPages(){
-        return moderatorPages;
-    }
-
-    @Bean
-    public String[] userPages(){
-        return userPages;
-    }
-
-    @Bean
-    public String moderatorRole(){
-        return moderatorRole;
-    }
-
-    @Bean
-    public String userRole(){
-        return userRole;
     }
 }

--- a/src/main/java/com/gibgab/service/security/JwtAuthorizationFilter.java
+++ b/src/main/java/com/gibgab/service/security/JwtAuthorizationFilter.java
@@ -1,26 +1,40 @@
 package com.gibgab.service.security;
 
+import com.gibgab.service.beans.SecurityConfiguration;
+import com.gibgab.service.database.entity.ApplicationUser;
+import com.gibgab.service.database.repository.UserRepository;
 import io.jsonwebtoken.Jwts;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.context.support.WebApplicationContextUtils;
 
 import javax.servlet.FilterChain;
+import javax.servlet.ServletContext;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
 
-import static com.gibgab.service.security.SecurityConstants.HEADER_STRING;
-import static com.gibgab.service.security.SecurityConstants.SECRET;
-import static com.gibgab.service.security.SecurityConstants.TOKEN_PREFIX;
+import static com.gibgab.service.security.SecurityConstants.*;
 
 public class JwtAuthorizationFilter extends BasicAuthenticationFilter {
 
-    public JwtAuthorizationFilter(AuthenticationManager authenticationManager) {
+    private UserRepository userRepository;
+    private SecurityConfiguration securityConfiguration;
+
+    public JwtAuthorizationFilter(AuthenticationManager authenticationManager, SecurityConfiguration securityConfiguration) {
         super(authenticationManager);
+        this.securityConfiguration = securityConfiguration;
     }
 
     @Override
@@ -52,10 +66,36 @@ public class JwtAuthorizationFilter extends BasicAuthenticationFilter {
                     .getSubject();
 
             if (user != null) {
-                return new UsernamePasswordAuthenticationToken(user, null, new ArrayList<>());
+                if(userRepository == null){
+                    ServletContext servletContext = request.getServletContext();
+                    WebApplicationContext webApplicationContext = WebApplicationContextUtils.getWebApplicationContext(servletContext);
+                    userRepository = webApplicationContext.getBean(UserRepository.class);
+                }
+
+                ApplicationUser applicationUser = userRepository.findByEmail(user);
+                Collection<? extends GrantedAuthority> authorities = getAuthoritiesFromApplicationUser(applicationUser);
+                return new UsernamePasswordAuthenticationToken(user, null, authorities);
             }
         }
 
         return null;
+    }
+
+
+    public Collection<? extends GrantedAuthority> getAuthoritiesFromApplicationUser(ApplicationUser user){
+        List<String> roles = new ArrayList<>();
+
+        if(!user.isActive()) {
+            roles = Collections.emptyList();
+        } else {
+            if(user.isActive()) roles.add("ROLE_" + securityConfiguration.userRole);
+            if(user.isModerator()) roles.add("ROLE_" + securityConfiguration.moderatorRole);
+        }
+
+        return getAuthorities(roles);
+    }
+
+    public Collection<? extends GrantedAuthority> getAuthorities(List<String> auths){
+        return auths.stream().map(SimpleGrantedAuthority::new).collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/gibgab/service/security/WebSecurity.java
+++ b/src/main/java/com/gibgab/service/security/WebSecurity.java
@@ -1,5 +1,6 @@
 package com.gibgab.service.security;
 
+import com.gibgab.service.beans.SecurityConfiguration;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpMethod;
@@ -21,30 +22,19 @@ public class WebSecurity extends WebSecurityConfigurerAdapter {
     private BCryptPasswordEncoder bCryptPasswordEncoder;
 
     @Autowired
-    private String[] publicAccessGetPages;
-    @Autowired
-    private String[] publicAccessPostPages;
-    @Autowired
-    private String[] moderatorPages;
-    @Autowired
-    private String[] userPages;
-
-    @Autowired
-    private String moderatorRole;
-    @Autowired
-    private String userRole;
+    private SecurityConfiguration securityConfiguration;
 
     @Override
     protected void configure(HttpSecurity http) throws Exception {
         http.csrf().disable().authorizeRequests()
-                .antMatchers(HttpMethod.POST, publicAccessPostPages).permitAll()
-                .antMatchers(HttpMethod.GET, publicAccessGetPages).permitAll()
-                .antMatchers(moderatorPages).hasRole(moderatorRole)
-                .antMatchers(userPages).hasRole(userRole)
+                .antMatchers(HttpMethod.POST, securityConfiguration.publicAccessPostPages).permitAll()
+                .antMatchers(HttpMethod.GET, securityConfiguration.publicAccessGetPages).permitAll()
+                .antMatchers(securityConfiguration.moderatorPages).hasRole(securityConfiguration.moderatorRole)
+                .antMatchers(securityConfiguration.userPages).hasRole(securityConfiguration.userRole)
                 .anyRequest().authenticated()
                 .and()
                 .addFilter(new JwtAuthenticationFilter(authenticationManager()))
-                .addFilter(new JwtAuthorizationFilter(authenticationManager()));
+                .addFilter(new JwtAuthorizationFilter(authenticationManager(), securityConfiguration));
     }
 
     @Override

--- a/src/main/java/com/gibgab/service/security/YammrUserDetailsService.java
+++ b/src/main/java/com/gibgab/service/security/YammrUserDetailsService.java
@@ -1,10 +1,12 @@
 package com.gibgab.service.security;
 
+import com.gibgab.service.beans.SecurityConfiguration;
 import com.gibgab.service.database.entity.ApplicationUser;
 import com.gibgab.service.database.entity.BanEvent;
 import com.gibgab.service.database.repository.BanEventRepository;
 import com.gibgab.service.database.repository.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Primary;
 import org.springframework.security.authentication.DisabledException;
 import org.springframework.security.authentication.LockedException;
 import org.springframework.security.core.GrantedAuthority;
@@ -23,12 +25,11 @@ import java.util.List;
 import static java.util.Collections.emptyList;
 
 @Service
+@Primary
 public class YammrUserDetailsService implements UserDetailsService {
 
     @Autowired
-    private String userRole;
-    @Autowired
-    private String moderatorRole;
+    private SecurityConfiguration securityConfiguration;
 
     private UserRepository userRepository;
 
@@ -64,10 +65,10 @@ public class YammrUserDetailsService implements UserDetailsService {
 
         if(applicationUser.isActive()) {
             if(applicationUser.isVerified()){
-                privileges.add("ROLE_" + userRole);
+                privileges.add("ROLE_" + securityConfiguration.userRole);
             }
             if (applicationUser.isModerator()) {
-                privileges.add("ROLE_" + moderatorRole);
+                privileges.add("ROLE_" + securityConfiguration.moderatorRole);
             }
 
             List<GrantedAuthority> authorities = new ArrayList<>();

--- a/src/test/java/com/gibgab/service/controller/DeleteUserControllerTest.java
+++ b/src/test/java/com/gibgab/service/controller/DeleteUserControllerTest.java
@@ -34,7 +34,7 @@ public class DeleteUserControllerTest {
     @Test
     @WithMockUser(username = username)
     public void deleteUserDeletesUser() throws Exception {
-        ApplicationUser applicationUser = new ApplicationUser();
+        ApplicationUser applicationUser = ApplicationUser.builder().build();
 
         when(userRepository.findByEmail(username)).thenReturn(applicationUser);
 


### PR DESCRIPTION
Fixes authorization issues. Closes #29 as a side-effect.

The problem was caused by `@Bean` and `@Autowired` being used incorrectly.  `@Autowire` cannot be used for primitive and String types.  Instead, `@Autowire` the configuration class with these fields.