### PR TITLE
Added service to list posts relative to a post id

### DIFF
--- a/src/main/java/com/gibgab/service/controller/FeedController.java
+++ b/src/main/java/com/gibgab/service/controller/FeedController.java
@@ -28,10 +28,13 @@ public class FeedController {
     private int pageLimit;
 
     @GetMapping({"/feed"})
-    public @ResponseBody List<Post> get_feed() {
-        return postRepository.findByOrderByIdDesc(PageRequest.of(0, pageLimit));
+    public @ResponseBody List<Post> get_feed_from_index(@RequestParam("start") Optional<Integer> start_id) {
+        if ( start_id.isPresent() )
+            return postRepository.findByIdGreaterThanOrderByIdDesc(start_id.get(), PageRequest.of(0, pageLimit));
+        else
+            return postRepository.findByOrderByIdDesc(PageRequest.of(0, pageLimit));
     }
-    
+
     @GetMapping("/feed/{page}")
     public @ResponseBody List<Post> get_feed(@PathVariable int page) {
         return postRepository.findByOrderByIdDesc(PageRequest.of(page, pageLimit));

--- a/src/main/java/com/gibgab/service/database/repository/PostRepository.java
+++ b/src/main/java/com/gibgab/service/database/repository/PostRepository.java
@@ -9,4 +9,5 @@ import java.util.List;
 
 public interface PostRepository extends CrudRepository<Post, Integer> {
     List<Post> findByOrderByIdDesc(Pageable page);
+    List<Post> findByIdGreaterThanOrderByIdDesc(int id, Pageable page);
 }


### PR DESCRIPTION
TODO: @4ndr3w create sprint ticket for this change

Adds a `start` param to the feed service, starting the page after a given post ID (exclusive).